### PR TITLE
fix(pack.sh): return error when jq is not installed

### DIFF
--- a/pack.sh
+++ b/pack.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e # exit when any command fails
 
 VER=`cat src/manifest.json| jq -r '.version'`
 


### PR DESCRIPTION
Prints a meaningful error when jq is not installed instead of failing silently 