### PR TITLE
Fix missing kana in TweetDeck

### DIFF
--- a/src/content_scripts/twitter.js
+++ b/src/content_scripts/twitter.js
@@ -197,6 +197,7 @@ const registerDeckMutationHook = () => {
             }
 
             const textSpan = document.createElement("span");
+            textSpan.textContent = textContent;
             article.replaceChild(textSpan, c);
             tweetBag.push({
               c: textSpan,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1979746/201002156-bd32f3ec-cc80-4d21-aaa7-f6468fd87ba3.png)
![image](https://user-images.githubusercontent.com/1979746/201002331-35d97a0d-847c-4d0a-b58e-09ef53161103.png)
https://twitter.com/museumnews_jp/status/1590543937928065024