### PR TITLE
Make extension work with OldTwitter

### DIFF
--- a/src/content_scripts/twitter.js
+++ b/src/content_scripts/twitter.js
@@ -217,7 +217,7 @@ const registerDeckMutationHook = () => {
 
 // main
 log('initialized.');
-registerMutationHook();
+setTimeout(registerMutationHook, 1000);
 registerDeckMutationHook();
 
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {

--- a/src/content_scripts/twitter.js
+++ b/src/content_scripts/twitter.js
@@ -217,7 +217,7 @@ const registerDeckMutationHook = () => {
 
 // main
 log('initialized.');
-setTimeout(registerMutationHook, 1000);
+setTimeout(registerMutationHook, 100);
 registerDeckMutationHook();
 
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {

--- a/src/content_scripts/twitter.js
+++ b/src/content_scripts/twitter.js
@@ -217,8 +217,9 @@ const registerDeckMutationHook = () => {
 
 // main
 log('initialized.');
+// delay hook registration to give other extensions time to inject
 setTimeout(registerMutationHook, 100);
-registerDeckMutationHook();
+setTimeout(registerDeckMutationHook, 100);
 
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   const { event, value } = request;


### PR DESCRIPTION
I'm creator of [OldTwitter](https://github.com/dimdenGD/OldTwitter/) extension, and I'd like to make your extension work with mine. I've already did the changes to my extension in [this](https://github.com/dimdenGD/OldTwitter/commit/f487102111cc90de3220b1e5dd02504576943cd7) commit in order to make your extension work seamlessly with mine, but there's still a code change needed in your extension, which is when observer is hooked. Just need to delay it a bit so OldTwitter has time to inject.  
  
Thank you, I'd appreciate if you merge and then update extension on Chrome Web Store, since I use your extension myself.