### PR TITLE
feat: update ruby color style based on theme preference

### DIFF
--- a/src/content_scripts/common.js
+++ b/src/content_scripts/common.js
@@ -154,6 +154,13 @@ const renderKanji = (hirakana, kanji) => {
 };
 
 const renderRuby = (container, token) => {
+  const isDarkMode = window.matchMedia('(prefers-color-scheme: dark)').matches;
+
+  const defaultColor = isDarkMode ? HIRAGANA_COLORS[5].value : HIRAGANA_COLORS[0].value
+
+  updateRubyColorStyle('miri-ruby-color', defaultColor);
+  SettingStorage.set({ color: defaultColor });
+
   // hidden ruby on contextmenu
   if (isChrome()) {
     const tweetContainer = container.parentElement;


### PR DESCRIPTION
Thank you all for maintaining such a useful Chrome Extension. ありがとうございます。

As mentioned in #28, the ruby text color defaults to black, which makes it invisible on dark-themed pages.

To address this, I've added some code that detects the current theme and automatically selects a matching color. This solves the visibility issue in an easy way.

However, this approach may conflict with the user's selected color. For example, if a user deliberately chooses purple in the popup, the code will still change it to white in dark mode.

I'm looking forward to hearing your thoughts and suggestions on this!